### PR TITLE
Removed unsafe usage of priority values

### DIFF
--- a/PriorityMod/PriorityMod.toml
+++ b/PriorityMod/PriorityMod.toml
@@ -1,15 +1,15 @@
 ## DO NOT try any value which not listed below.
 
 ## Priorities
-# Idle          = 64
-# Below Normal  = 16384
-# Normal        = 32
-# Above Normal  = 32768
-# High          = 128
-# Realtime      = 256   (Run as Administrator is required) (Not Recommended)
+# Idle          = 0
+# Below Normal  = 1
+# Normal        = 2
+# Above Normal  = 3
+# High          = 4
+# Realtime      = 5     (Run as Administrator is required) (Not Recommended)
 
 ## Check Microsoft official document for the details
 # https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass#parameters
 
 [PriorityMod]
-priority=128
+priority=4

--- a/PriorityMod/dllmain.cpp
+++ b/PriorityMod/dllmain.cpp
@@ -6,19 +6,31 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 	LPVOID lpReserved
 )
 {
+	int priority_classes[] = {
+		IDLE_PRIORITY_CLASS,
+		BELOW_NORMAL_PRIORITY_CLASS,
+		NORMAL_PRIORITY_CLASS,
+		ABOVE_NORMAL_PRIORITY_CLASS,
+		HIGH_PRIORITY_CLASS,
+		REALTIME_PRIORITY_CLASS
+	};
+
 	switch (ul_reason_for_call)
 	{
 	case DLL_PROCESS_ATTACH:
 		int priority;
+
 		if (std::filesystem::exists("Data/SKSE/Plugins/PriorityMod.toml"))
 		{
 			auto config = toml::parse_file("Data/SKSE/Plugins/PriorityMod.toml");
-			priority = config["PriorityMod"]["priority"].value_or(HIGH_PRIORITY_CLASS);
+			int value = config["PriorityMod"]["priority"].value_or(4);
+			priority = priority_classes[(value >= 0 && value <= 5) ? value : 4];
 		}
 		else if (std::filesystem::exists("Data/F4SE/Plugins/PriorityMod.toml"))
 		{
 			auto config = toml::parse_file("Data/F4SE/Plugins/PriorityMod.toml");
-			priority = config["PriorityMod"]["priority"].value_or(HIGH_PRIORITY_CLASS);
+			int value = config["PriorityMod"]["priority"].value_or(4);
+			priority = priority_classes[(value >= 0 && value <= 5) ? value : 4];
 		}
 		else
 		{

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Ensured the game **always take most of CPU usage, prevent suddenly lag caused by other processes**.  
 Kick other processes out. Skyrim/Fallout is the only one who should have whole CPU.  
 
-## Priority Classes
+## Priority Levels
 |     Priority | Value | 
 |------------- |------ |
 | Idle         | 0     |

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Kick other processes out. Skyrim/Fallout is the only one who should have whole C
 ## Priority Classes
 |     Priority | Value | 
 |------------- |------ |
-| Idle         | 64    |
-| Below Normal | 16384 |
-| Normal       | 32    |
-| Above Normal | 32768 |
-| High         | 128   |
-| Realtime     | 256   |
+| Idle         | 0     |
+| Below Normal | 1     |
+| Normal       | 2     |
+| Above Normal | 3     |
+| High         | 4     |
+| Realtime     | 5     |
 
 > This mod uses `High` by default  
 > You can change it in `PriorityMod.toml`


### PR DESCRIPTION
Changes:
* Removed unsafe direct usage of priority level, as a simple typo in the config file might cause havoc on the system.
* Inputting an invalid value will now default back to 4 (High).

These are the new values:
|     Priority | Value | 
|------------- |------ |
| Idle         | 0     |
| Below Normal | 1     |
| Normal       | 2     |
| Above Normal | 3     |
| High         | 4     |
| Realtime     | 5     |

I've got [precompiled binaries](https://github.com/WaCrex/PriorityMod/releases/tag/2.1.0) available for download in my fork if anyone want to test it on their system.

